### PR TITLE
Suggestion: Linking to real blog repo

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,6 @@
 AUTHOR = 'Daniel Greenfeld'
 DISQUS_SITENAME = 'pydanny'
-GITHUB_URL = 'https://github.com/pydanny'
+GITHUB_URL = 'https://github.com/pydanny/pydanny.github.com'
 GOOGLE_ANALYTICS='UA-18066389-2'
 SITEURL = 'http://pydanny.github.com'
 SITENAME = 'pydanny'


### PR DESCRIPTION
Hey I think the point of the "Fork me on GitHb" badge is to get to the repository of the project you are currently seeing (in this case: your blog). Threrefore it would probably be better to actually link to that project instead of your general GitHub profile.

Just an idea...
